### PR TITLE
Fix DnsQuestion equality

### DIFF
--- a/DnsCore/DnsCore.csproj
+++ b/DnsCore/DnsCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../DnsCore.targets" />
   <PropertyGroup>
-    <Version>0.1.29</Version>
+    <Version>0.1.30</Version>
     <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
     <Authors>Vasyl Novikov</Authors>
     <Description>.NET lightweight DNS server &amp; client</Description>

--- a/DnsCore/Model/DnsQuestion.cs
+++ b/DnsCore/Model/DnsQuestion.cs
@@ -10,7 +10,7 @@ public sealed class DnsQuestion(DnsName name, DnsRecordType recordType, DnsClass
 {
     public bool Equals(DnsQuestion? other) => other is not null && Class == other.Class && RecordType == other.RecordType && Name == other.Name;
 
-    public override bool Equals(object? obj) => obj is DnsName name && Equals(name);
+    public override bool Equals(object? obj) => obj is DnsQuestion question && Equals(question);
 
     public override int GetHashCode() => HashCode.Combine(Name, RecordType, Class);
 


### PR DESCRIPTION
## Summary
- fix `DnsQuestion.Equals` object override
- bump `DnsCore` NuGet package version

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840828e046083249c72b4f573b00beb